### PR TITLE
Add migrations_paths as configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ActiveRecordMigrations.configure do |c|
   # c.yaml_config = 'db/config.yml'
   # c.environment = ENV['db']
   # c.db_dir = 'db'
+  # c.migrations_paths = ['db/migrate']
 end
 ```
 

--- a/lib/active_record_migrations.rb
+++ b/lib/active_record_migrations.rb
@@ -26,6 +26,7 @@ module ActiveRecordMigrations
       configurations.database_configuration
     DatabaseTasks.current_config = configurations.database_configuration[configurations.environment]
     DatabaseTasks.db_dir = configurations.db_dir
+    DatabaseTasks.migrations_paths = configurations.migrations_paths
   end
 
   private

--- a/lib/active_record_migrations/configurations.rb
+++ b/lib/active_record_migrations/configurations.rb
@@ -5,12 +5,13 @@ module ActiveRecordMigrations
   class Configurations
     include Singleton
 
-    attr_accessor :yaml_config, :database_configuration, :environment, :db_dir, :schema_format, :seed_loader
+    attr_accessor :yaml_config, :database_configuration, :environment, :db_dir, :migrations_paths, :schema_format, :seed_loader
 
     def initialize
       @yaml_config = 'db/config.yml'
       @environment = ENV['db'] || Rails.env
       @db_dir = 'db'
+      @migrations_paths = ['db/migrate']
       @schema_format = :ruby # or :sql
       @seed_loader = Rails.application
     end


### PR DESCRIPTION
Allows to set where to find the migration files, if they for some reason are not located in the default db/migrate directory.
