### PR TITLE
make a 4.1.9.1 version

### DIFF
--- a/active_record_migrations.gemspec
+++ b/active_record_migrations.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # So it's better to fix on an specific version of AR and check if the override of
   # ActiveRecord::Generators::MigrationGenerator#create_migration_file is correct
   # before upgrading AR dependency. See ARM::Generators::MigrationGenerator impl.
-  spec.add_dependency "railties", "4.2.0"
-  spec.add_dependency "activerecord", "4.2.0"
+  spec.add_dependency "railties", "4.1.9"
+  spec.add_dependency "activerecord", "4.1.9"
 end
 

--- a/lib/active_record_migrations/version.rb
+++ b/lib/active_record_migrations/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordMigrations
-  VERSION = "4.2.0.1"
+  VERSION = "4.1.9.1"
 end


### PR DESCRIPTION
I needed a 4.1.9.1 version.  Would be great to get an official release so I don't need to run this fork.