### PR TITLE
Enable pessimistic gemspec 

### DIFF
--- a/active_record_migrations.gemspec
+++ b/active_record_migrations.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # So it's better to fix on an specific version of AR and check if the override of
   # ActiveRecord::Generators::MigrationGenerator#create_migration_file is correct
   # before upgrading AR dependency. See ARM::Generators::MigrationGenerator impl.
-  spec.add_dependency "railties", "4.2.1"
-  spec.add_dependency "activerecord", "4.2.1"
+  spec.add_dependency "railties", "~>4.0"
+  spec.add_dependency "activerecord", "~>4.0"
 end
 

--- a/lib/active_record_migrations/generators/migration.rb
+++ b/lib/active_record_migrations/generators/migration.rb
@@ -10,6 +10,7 @@ module ActiveRecordMigrations
         set_local_assigns!
         validate_file_name!
         dir = ::ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first
+        @migration_template ||= 'migration.rb'
         migration_template @migration_template, "#{dir}/#{file_name}.rb"
       end
     end


### PR DESCRIPTION
We have a project that needs migrations and is also included in a Rails app.  Due to the locked 4.0.1 gemspec this reverts our Rails version to 4.0.13.  Looking at the Rails Active Record Migrations code base, I think this is the only piece missing to make this work back to 2011 code base?
