### PR TITLE
Fix Psych 4 incompatibility

### DIFF
--- a/lib/active_record_migrations/configurations.rb
+++ b/lib/active_record_migrations/configurations.rb
@@ -20,7 +20,14 @@ module ActiveRecordMigrations
     alias configure instance_eval
 
     def database_configuration
-      @database_configuration ||= YAML.load(ERB.new(File.read @yaml_config).result)
+      @database_configuration ||=
+        begin
+          content = ERB.new(File.read @yaml_config).result
+
+          YAML.load(content, aliases: true)
+        rescue ArgumentError
+          YAML.load(content)
+        end
     end
   end
 end


### PR DESCRIPTION
Ruby 3.1 includes Psych 4 by default which will not support aliases by default anymore. So we're explicitly allowing aliases now.

This is in line with Rails' changes

https://github.com/rails/rails/pull/42249


## Steps to reproduce

Given the following minimal example:

```ruby
# Gemfile
source 'https://rubygems.org'

gem 'active_record_migrations'
gem 'sqlite3'
```

```ruby
# Rakefile
require 'bundler/setup'
Bundler.require

ActiveRecordMigrations.load_tasks
```

```yml
# db/config.yml
default: &default
  adapter: sqlite3

development:
  <<: *default
  database: db/development.sqlite3

test:
  <<: *default
  database: db/test.sqlite3
```


When running `rake db:migrate` in Ruby 3.0.x everything works as expected and an empty database file is created. In Ruby 3.1.3 however I get 

```
rake aborted!
Psych::BadAlias: Unknown alias: default
xxx/.rvm/gems/ruby-3.1.3/gems/active_record_migrations-6.1.1.3/lib/active_record_migrations/configurations.rb:23:in `database_configuration'
xxx/.rvm/gems/ruby-3.1.3/gems/active_record_migrations-6.1.1.3/lib/active_record_migrations.rb:35:in `load_tasks'
/private/tmp/minimal/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```